### PR TITLE
Include depth in table, rework plot, clean up code

### DIFF
--- a/R/data_processing.R
+++ b/R/data_processing.R
@@ -87,8 +87,20 @@ compute_teros <- function(teros, ddt) {
         distinct(ID, Logger, .keep_all = TRUE) ->
         teros_bad_sensors
 
+    teros_filtered %>%
+        # retain only the 10 most recent observations
+        arrange(Timestamp) %>%
+        group_by(ID, variable) %>%
+        slice_tail(n = 10) %>%
+        ungroup() %>%
+        select(Timestamp, ID, Plot, variable, Grid_Square, Depth, value) %>%
+        pivot_wider(id_cols = c("ID", "Plot", "variable", "Grid_Square", "Depth"),
+                    names_from = "Timestamp", values_from = "value") ->
+        teros_table_data
+
     list(teros = teros,
          teros_bad_sensors = teros_bad_sensors,
+         teros_table_data = teros_table_data,
          teros_bdg = teros_bdg)
 }
 

--- a/R/process_teros.R
+++ b/R/process_teros.R
@@ -17,21 +17,23 @@ process_teros <- function(token, datadir) {
         progress <- NULL
     }
     teros_primitive <- compasstools::process_teros_dir(datadir, tz = "EST",
-                                                      dropbox_token = token,
-                                                      progress_bar = progress)
-
+                                                       dropbox_token = token,
+                                                       progress_bar = progress)
 
     teros_primitive %>%
-        left_join(teros_inventory, by = c("Logger" = "Data Logger ID",
-                                          "Data_Table_ID" = "Terosdata table channel")) %>%
+        left_join(teros_inventory,
+                  by = c("Logger" = "Data Logger ID",
+                         "Data_Table_ID" = "Terosdata table channel")) %>%
         select(- `Date of Last Field Check`) %>%
         rename("Active_Date" = "Date Online (2020)",
                "Grid_Square" = "Grid Square") %>%
+        mutate(Depth = as.factor(Depth)) %>%
         filter(!is.na(ID)) ->
         teros
 
-    nomatch <- anti_join(teros, teros_inventory, by = c("Logger" = "Data Logger ID",
-                                                            "Data_Table_ID" = "Terosdata table channel"))
+    nomatch <- anti_join(teros, teros_inventory,
+                         by = c("Logger" = "Data Logger ID",
+                                "Data_Table_ID" = "Terosdata table channel"))
     if(nrow(nomatch) > 0) {
         warning("There were logger/channel combinations that I couldn't find in teros_inventory.csv:")
     }

--- a/server.R
+++ b/server.R
@@ -337,13 +337,27 @@ server <- function(input, output, session) {
 
             dropbox_data()[["teros"]] %>%
                 filter(ID %in% tsensor_selected$ID,
-                       variable %in% tsensor_selected$variable) %>%
-                ggplot(aes(Timestamp, value, group = interaction(ID, variable),
-                           color = Depth)) +
-                geom_line() +
+                       variable %in% tsensor_selected$variable) -> selected_data
+
+            # Try to assign color intelligently. If different plots are selected,
+            # have that be the color; otherwise by depth; otherwise by ID
+            if(length(unique(selected_data$Plot)) > 1) {
+                b <- ggplot(selected_data,
+                            aes(Timestamp, value, group = interaction(ID, variable),
+                                color = Plot))
+            } else if(length(unique(selected_data$Depth)) > 1)  {
+                b <- ggplot(selected_data,
+                            aes(Timestamp, value, group = interaction(ID, variable),
+                                color = Depth))
+            } else {
+                b <- ggplot(selected_data,
+                            aes(Timestamp, value, group = interaction(ID, variable),
+                                color = ID))
+            }
+
+            b <- b + geom_line() +
                 xlab("") +
-                xlim(c(ddt - GRAPH_TIME_WINDOW * 60 * 60, ddt)) ->
-                b
+                xlim(c(ddt - GRAPH_TIME_WINDOW * 60 * 60, ddt))
         } else {
             b <- NO_DATA_GRAPH
         }

--- a/server.R
+++ b/server.R
@@ -290,7 +290,6 @@ server <- function(input, output, session) {
 
     output$sapflow_table <- DT::renderDataTable(datatable({
         dataInvalidate()
-
         dropbox_data()[["sapflow_table_data"]]
     }))
 
@@ -323,15 +322,7 @@ server <- function(input, output, session) {
 
     output$teros_table <- renderDataTable({
         dataInvalidate()
-
-        dropbox_data()[["teros"]] %>%
-            group_by(ID, variable) %>%
-            slice_tail(n = 10) %>%
-            ungroup() %>%
-            select(Timestamp, ID, Plot, variable, value, Logger, Grid_Square) %>%
-            arrange(Timestamp) %>%
-            pivot_wider(id_cols = c("ID", "Plot", "variable", "Grid_Square"),
-                        names_from = "Timestamp", values_from = "value")
+        dropbox_data()[["teros_table_data"]]
     })
 
     output$teros_detail_graph <- renderPlotly({
@@ -339,21 +330,16 @@ server <- function(input, output, session) {
         if(length(input$teros_table_rows_selected)) {
             ddt <- reactive({ DASHBOARD_DATETIME() })()
 
-            dropbox_data()[["teros"]] %>%
-                group_by(ID, variable) %>%
-                slice_tail(n = 10) %>%
-                ungroup() %>%
-                select(Timestamp, ID, variable, value, Logger, Grid_Square) %>%
-                arrange(Timestamp) %>%
-                pivot_wider(id_cols = c("ID", "variable", "Grid_Square"),
-                            names_from = "Timestamp", values_from = "value") %>%
+            dropbox_data()[["teros_table_data"]] %>%
                 slice(input$teros_table_rows_selected) %>%
                 select(variable, ID) ->
                 tsensor_selected
 
             dropbox_data()[["teros"]] %>%
-                filter(ID %in% tsensor_selected$ID, variable %in% tsensor_selected$variable) %>%
-                ggplot(aes(Timestamp, value, group = interaction(ID, variable), color = ID)) +
+                filter(ID %in% tsensor_selected$ID,
+                       variable %in% tsensor_selected$variable) %>%
+                ggplot(aes(Timestamp, value, group = interaction(ID, variable),
+                           color = Depth)) +
                 geom_line() +
                 xlab("") +
                 xlim(c(ddt - GRAPH_TIME_WINDOW * 60 * 60, ddt)) ->


### PR DESCRIPTION
Include `Depth` in the TEROS table, and try to be intelligent about which variable is used for the color aesthetic.

If different plots are selected, we assume the user wants to compare them:

<img width="928" alt="Screenshot 2024-06-08 at 7 12 16 AM" src="https://github.com/COMPASS-DOE/TEMPESTdash/assets/1956468/038842ec-9cbe-4e19-ad6a-c3060d88447a">

Otherwise, if different depths are selected:

<img width="1253" alt="Screenshot 2024-06-08 at 6 58 43 AM" src="https://github.com/COMPASS-DOE/TEMPESTdash/assets/1956468/011fe1df-8fff-4294-ba44-d1a7f23276fa">

And if neither of these, we assume ID: 

<img width="929" alt="Screenshot 2024-06-08 at 7 13 22 AM" src="https://github.com/COMPASS-DOE/TEMPESTdash/assets/1956468/3b14a7e5-c832-4a8f-bfb2-4d3a41fc2de0">
