### PR TITLE
Add range slider to overview graphs

### DIFF
--- a/R/add_range.R
+++ b/R/add_range.R
@@ -15,6 +15,6 @@ add_range <- function(p) {
                             label = "Today",
                             step = "day",
                             stepmode = "todate"),
-                        list(step = "all"))),
+                        list(step = "All"))),
                 rangeslider = list(type = "date")))
 }

--- a/R/add_range.R
+++ b/R/add_range.R
@@ -12,9 +12,9 @@ add_range <- function(p) {
                     buttons = list(
                         list(
                             count = 1,
-                            label = "Today",
+                            label = "today",
                             step = "day",
                             stepmode = "todate"),
-                        list(step = "All"))),
+                        list(step = "all"))),
                 rangeslider = list(type = "date")))
 }

--- a/R/add_range.R
+++ b/R/add_range.R
@@ -1,0 +1,20 @@
+
+# Function to add range selector to plotly
+# Created 2024-06-07 | Stephanie Pennington
+
+add_range <- function(p) {
+    p %>%
+        layout(
+            xaxis = list(
+                range = c(Sys.Date() - 1, Sys.Date()),
+                type = "date",
+                rangeselector = list(
+                    buttons = list(
+                        list(
+                            count = 1,
+                            label = "Today",
+                            step = "day",
+                            stepmode = "todate"),
+                        list(step = "all"))),
+                rangeslider = list(type = "date")))
+}

--- a/R/process_sapflow.R
+++ b/R/process_sapflow.R
@@ -18,6 +18,7 @@ process_sapflow <- function(token, datadir) {
 
     sf_raw <- compasstools::process_sapflow_dir(datadir, tz = "EST",
                                                 token, progress)
+
     sf_raw %>%
         left_join(sf_inventory, by = c("Logger", "Port")) %>%
         filter(!is.na(Tree_Code)) %>% # remove ports that don't have any sensors

--- a/server.R
+++ b/server.R
@@ -52,7 +52,7 @@ server <- function(input, output, session) {
         dataInvalidate()
 
         if(TESTING) {
-            sapflow <- readRDS("offline-data/sapflow")
+            sapflow <- readRDS("offline-data/sapflow") %>% rename(Sapflow_ID = Tree_Code)
             teros <- readRDS("offline-data/teros")
             aquatroll <- readRDS("offline-data/aquatroll")
             battery <- readRDS("offline-data/battery")
@@ -152,7 +152,6 @@ server <- function(input, output, session) {
         datatable(vals, options = list(searching = FALSE, pageLength = 5))
     })
 
-
     # ------------------ Main dashboard graphs ---------------------------
 
     # Define a semi-transparent rectangle to indicate flood start/stop
@@ -170,11 +169,11 @@ server <- function(input, output, session) {
         # Average sapflow data by plot and 15 minute interval
         # This graph is shown when users click the "Sapflow" tab on the dashboard
         ddt <- reactive({ DASHBOARD_DATETIME() })()
-        dropbox_data()[["sapflow"]] %>%
-            filter_recent_timestamps(GRAPH_TIME_WINDOW, ddt) ->
+        dropbox_data()[["sapflow"]] ->
             sapflow
 
         if(nrow(sapflow)) {
+
             sapflow %>%
                 mutate(Timestamp_rounded = round_date(Timestamp, GRAPH_TIME_INTERVAL)) %>%
                 group_by(Plot, Logger, Timestamp_rounded) %>%
@@ -189,7 +188,8 @@ server <- function(input, output, session) {
         } else {
             b <- NO_DATA_GRAPH
         }
-        plotly::ggplotly(b)
+        plotly::ggplotly(b, dynamicTicks = TRUE) %>%
+            add_range()
     })
 
     output$teros_plot <- renderPlotly({
@@ -198,8 +198,7 @@ server <- function(input, output, session) {
         # This graph is shown when users click the "TEROS" tab on the dashboard
 
         ddt <- reactive({ DASHBOARD_DATETIME() })()
-        dropbox_data()[["teros"]] %>%
-            filter_recent_timestamps(GRAPH_TIME_WINDOW, ddt) ->
+        dropbox_data()[["teros"]] ->
             teros
 
         if(nrow(teros)) {
@@ -226,7 +225,8 @@ server <- function(input, output, session) {
         } else {
             b <- NO_DATA_GRAPH
         }
-        plotly::ggplotly(b)
+        plotly::ggplotly(b) %>%
+            add_range()
     })
 
     output$aquatroll_plot <- renderPlotly({
@@ -238,8 +238,7 @@ server <- function(input, output, session) {
 
         ddt <- reactive({ DASHBOARD_DATETIME() })()
         bind_rows(dropbox_data()[["aquatroll_200_long"]],
-                  dropbox_data()[["aquatroll_600_long"]]) %>%
-            filter_recent_timestamps(GRAPH_TIME_WINDOW, ddt) ->
+                  dropbox_data()[["aquatroll_600_long"]]) ->
             full_trolls_long
 
         if(nrow(full_trolls_long) > 1) {
@@ -255,11 +254,12 @@ server <- function(input, output, session) {
                 facet_wrap(~variable, scales = "free") +
                 xlab("") ->
                 b
-
+browser()
         } else {
             b <- NO_DATA_GRAPH
         }
-        plotly::ggplotly(b)
+        plotly::ggplotly(b) %>%
+            add_range()
     })
 
     output$battery_plot <- renderPlotly({
@@ -282,7 +282,8 @@ server <- function(input, output, session) {
         } else {
             b <- NO_DATA_GRAPH
         }
-        plotly::ggplotly(b)
+        plotly::ggplotly(b) %>%
+            add_range()
     })
 
 

--- a/server.R
+++ b/server.R
@@ -213,7 +213,9 @@ server <- function(input, output, session) {
                 left_join(TEROS_RANGE, by = c("var" = "variable")) ->
                 tdat
 
-            ggplot(tdat) +
+            tdat %>%
+                filter(var == "EC") %>%
+                ggplot() +
                 shaded_flood_rect(ymin = low, ymax = high) +
                 facet_wrap(~var, scales = "free", ncol = 2) +
                 geom_line(aes(Timestamp_rounded, value, color = Plot, group = Logger)) +
@@ -221,12 +223,40 @@ server <- function(input, output, session) {
                 coord_cartesian(xlim = c(ddt - GRAPH_TIME_WINDOW * 60 * 60, ddt)) +
                 geom_hline(aes(yintercept = low), color = "grey", linetype = 2) +
                 geom_hline(aes(yintercept = high), color = "grey", linetype = 2) ->
-                b
+                b1
+
+            tdat %>%
+                filter(var == "TSOIL") %>%
+                ggplot() +
+                shaded_flood_rect(ymin = low, ymax = high) +
+                facet_wrap(~var, scales = "free", ncol = 2) +
+                geom_line(aes(Timestamp_rounded, value, color = Plot, group = Logger)) +
+                xlab("") +
+                coord_cartesian(xlim = c(ddt - GRAPH_TIME_WINDOW * 60 * 60, ddt)) +
+                geom_hline(aes(yintercept = low), color = "grey", linetype = 2) +
+                geom_hline(aes(yintercept = high), color = "grey", linetype = 2) ->
+                b2
+
+            tdat %>%
+                filter(var == "VWC") %>%
+                ggplot() +
+                shaded_flood_rect(ymin = low, ymax = high) +
+                facet_wrap(~var, scales = "free", ncol = 2) +
+                geom_line(aes(Timestamp_rounded, value, color = Plot, group = Logger)) +
+                xlab("") +
+                coord_cartesian(xlim = c(ddt - GRAPH_TIME_WINDOW * 60 * 60, ddt)) +
+                geom_hline(aes(yintercept = low), color = "grey", linetype = 2) +
+                geom_hline(aes(yintercept = high), color = "grey", linetype = 2) ->
+                b3
+
         } else {
             b <- NO_DATA_GRAPH
         }
-        plotly::ggplotly(b) %>%
-            add_range()
+
+        subplot(ggplotly(b1, tooltip="text", dynamicTicks = TRUE) %>% add_range(),
+                (ggplotly(b2, tooltip="text", dynamicTicks = TRUE) %>% add_range()),
+                (ggplotly(b3, tooltip="text", dynamicTicks = TRUE) %>% add_range()),
+                nrows=3, shareX = TRUE, shareY = TRUE)
     })
 
     output$aquatroll_plot <- renderPlotly({
@@ -247,30 +277,68 @@ server <- function(input, output, session) {
                 left_join(AQUATROLL_RANGE, by = "variable") %>%
                 # Certain versions of plotly seem to have a bug and produce
                 # a tidyr::pivot error when there's a 'variable' column; rename
-                rename(var = variable) %>%
-                ggplot(aes(Timestamp_rounded, value, color = Well_Name)) +
+                rename(var = variable) -> t
+
+                t %>%
+                    filter(var == "Pressure_psi") %>%
+                    ggplot(aes(Timestamp_rounded, value, color = Well_Name)) +
                 coord_cartesian(xlim = c(ddt - GRAPH_TIME_WINDOW * 60 * 60, ddt)) +
                 shaded_flood_rect(ymin = low, ymax = high) +
                 geom_line() +
                 geom_hline(aes(yintercept = low), color = "grey", linetype = 2) +
                 geom_hline(aes(yintercept = high), color = "grey", linetype = 2) +
                 facet_wrap(~var, scales = "free", ncol = 2) +
-                xlab("") ->
-                b
-browser()
+                xlab("") -> t1
+
+                t %>%
+                    filter(var == "Salinity") %>%
+                    ggplot(aes(Timestamp_rounded, value, color = Well_Name)) +
+                    coord_cartesian(xlim = c(ddt - GRAPH_TIME_WINDOW * 60 * 60, ddt)) +
+                    shaded_flood_rect(ymin = low, ymax = high) +
+                    geom_line() +
+                    geom_hline(aes(yintercept = low), color = "grey", linetype = 2) +
+                    geom_hline(aes(yintercept = high), color = "grey", linetype = 2) +
+                    facet_wrap(~var, scales = "free", ncol = 2) +
+                    xlab("") -> t2
+
+                t %>%
+                    filter(var == "Temp") %>%
+                    ggplot(aes(Timestamp_rounded, value, color = Well_Name)) +
+                    coord_cartesian(xlim = c(ddt - GRAPH_TIME_WINDOW * 60 * 60, ddt)) +
+                    shaded_flood_rect(ymin = low, ymax = high) +
+                    geom_line() +
+                    geom_hline(aes(yintercept = low), color = "grey", linetype = 2) +
+                    geom_hline(aes(yintercept = high), color = "grey", linetype = 2) +
+                    facet_wrap(~var, scales = "free", ncol = 2) +
+                    xlab("") -> t3
+
+                t %>%
+                    filter(var == "DO_mgl") %>%
+                    ggplot(aes(Timestamp_rounded, value, color = Well_Name)) +
+                    coord_cartesian(xlim = c(ddt - GRAPH_TIME_WINDOW * 60 * 60, ddt)) +
+                    shaded_flood_rect(ymin = low, ymax = high) +
+                    geom_line() +
+                    geom_hline(aes(yintercept = low), color = "grey", linetype = 2) +
+                    geom_hline(aes(yintercept = high), color = "grey", linetype = 2) +
+                    facet_wrap(~var, scales = "free", ncol = 2) +
+                    xlab("") -> t4
+
         } else {
             b <- NO_DATA_GRAPH
         }
-        plotly::ggplotly(b) %>%
-            add_range()
+
+        subplot(ggplotly(t1, tooltip="text", dynamicTicks = TRUE) %>% add_range(),
+                (ggplotly(t2, tooltip="text", dynamicTicks = TRUE) %>% add_range()),
+                (ggplotly(t3, tooltip="text", dynamicTicks = TRUE) %>% add_range()),
+                (ggplotly(t4, tooltip="text", dynamicTicks = TRUE) %>% add_range()),
+                nrows=4, shareX = TRUE, shareY = TRUE)
     })
 
     output$battery_plot <- renderPlotly({
         # Battery voltages, from the sapflow data
         # This graph is shown when users click the "Battery" tab on the dashboard
         ddt <- reactive({ DASHBOARD_DATETIME() })()
-        dropbox_data()[["battery"]] %>%
-            filter_recent_timestamps(GRAPH_TIME_WINDOW, ddt) ->
+        dropbox_data()[["battery"]] ->
             battery
 
         if(nrow(battery)) {
@@ -285,7 +353,7 @@ browser()
         } else {
             b <- NO_DATA_GRAPH
         }
-        plotly::ggplotly(b) %>%
+        plotly::ggplotly(b, dynamicTicks = TRUE) %>%
             add_range()
     })
 


### PR DESCRIPTION
- Adds sliding range bars (note facets don't work well for this so I've used `subplot` to paste individual variable graphs together for teros and aquatroll which slows down rendering a bit but ok for now)
- Graphs full file of data to look back in time from TEMPEST event(s)

See #32 

<img width="1211" alt="image" src="https://github.com/COMPASS-DOE/TEMPESTdash/assets/20341158/b0ab8dcc-aac3-41bc-9c18-0e657cf19eef">
